### PR TITLE
fixed libtoon error and added libcvd

### DIFF
--- a/libcvd/Makefile
+++ b/libcvd/Makefile
@@ -10,7 +10,7 @@ include $(shell rospack find mk)/download_unpack_build.mk
 installed: $(SOURCE_DIR)/unpacked
 	# build
 	cd $(SOURCE_DIR) && ./configure
-	patch utility.patch
+	cd $(SOURCE_DIR)/cvd && patch < ../../../utility.patch
 	cd $(SOURCE_DIR) && make
 	
 	# copy to common

--- a/libcvd/Makefile
+++ b/libcvd/Makefile
@@ -1,0 +1,27 @@
+all: installed
+
+TARBALL = build/libcvd-20100511.tar.gz
+TARBALL_URL = http://www.edwardrosten.com/cvd/libcvd-20100511.tar.gz
+SOURCE_DIR = build/libcvd-20100511
+#MD5SUM_FILE = libtoon.tar.gz.md5sum
+
+include $(shell rospack find mk)/download_unpack_build.mk
+
+installed: $(SOURCE_DIR)/unpacked
+	# build
+	cd $(SOURCE_DIR) && ./configure
+	patch utility.patch
+	cd $(SOURCE_DIR) && make
+	
+	# copy to common
+	mkdir -p common
+	mkdir -p common/include
+	mkdir -p common/include/libcvd
+	cp -r $(SOURCE_DIR)/cvd/* common/include/libcvd
+	#cd common/include && ln -sf libcvd cvd
+	mkdir -p common/lib
+	#cp -r
+clean:
+	rm -rf common $(SOURCE_DIR) $(TARBALL)
+wipe: clean
+	-rm -rf build

--- a/libcvd/Makefile
+++ b/libcvd/Makefile
@@ -7,21 +7,23 @@ SOURCE_DIR = build/libcvd-20100511
 
 include $(shell rospack find mk)/download_unpack_build.mk
 
-installed: $(SOURCE_DIR)/unpacked
+installed: wipe $(SOURCE_DIR)/unpacked
 	# build
-	cd $(SOURCE_DIR) && ./configure
-	cd $(SOURCE_DIR)/cvd && patch < ../../../utility.patch
-	cd $(SOURCE_DIR) && make
+	cd $(SOURCE_DIR) && export CPATH=`rospack find libtoon`/common/include/ && ./configure
+	cd $(SOURCE_DIR)/cvd && patch -N < ../../../utility.patch
+	cd $(SOURCE_DIR) && export CPATH=`rospack find libtoon`/common/include/ && make
 	
 	# copy to common
 	mkdir -p common
 	mkdir -p common/include
 	mkdir -p common/include/libcvd
 	cp -r $(SOURCE_DIR)/cvd/* common/include/libcvd
-	#cd common/include && ln -sf libcvd cvd
+	cd common/include && ln -sf libcvd cvd
 	mkdir -p common/lib
-	#cp -r
+	cp $(SOURCE_DIR)/*.so* common/lib
+	touch ROS_NOBUILD
 clean:
 	rm -rf common $(SOURCE_DIR) $(TARBALL)
+	rm -rf ROS_NOBUILD
 wipe: clean
 	-rm -rf build

--- a/libcvd/mainpage.dox
+++ b/libcvd/mainpage.dox
@@ -1,0 +1,26 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b libcvd is ... 
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+
+<!--
+Provide links to specific auto-generated API documentation within your
+package that is of particular interest to a reader. Doxygen will
+document pretty much every part of your code, so do your best here to
+point the reader to the actual API.
+
+If your codebase is fairly large or has different sets of APIs, you
+should use the doxygen 'group' tag to keep these APIs together. For
+example, the roscpp documentation has 'libros' group.
+-->
+
+
+*/

--- a/libcvd/manifest.xml
+++ b/libcvd/manifest.xml
@@ -1,0 +1,20 @@
+<package>
+  <description brief="libcvd">
+
+     libcvd
+
+  </description>
+  <author>Edward Rosten, Paul Smith, Tom Drummond, Gerhard Reitmayr, Ethan Eade, Timothy Gan, Chris Kemp, Georg Klein</author>
+  <license>LGPL</license>
+  <review status="unreviewed" notes=""/>
+  <url>savannah.nongnu.org/projects/libcvd</url>
+
+  <depend package="libtoon"/>
+
+  <rosdep name="cvs"/>
+
+  <export>
+    <cpp cflags="-I${prefix}/common/include -I${prefix}/common/include/cvd" lflags="-L${prefix}/common/lib"/>
+  </export>
+
+</package>

--- a/libcvd/utility.h.patch.rmb
+++ b/libcvd/utility.h.patch.rmb
@@ -1,0 +1,231 @@
+#ifndef CVD_UTILITY_H
+#define CVD_UTILITY_H
+
+#include <cvd/image.h>
+#include <cvd/internal/is_pod.h>
+#include <cvd/internal/pixel_traits.h>
+#include <cvd/internal/convert_pixel_types.h>
+#include <sys/types.h>
+
+namespace CVD { //begin namespace
+
+  /** Generic image copy function for copying sub rectangles of images into
+  other images. This performs pixel type conversion if the input and output
+  images are different pixel types.
+  @param in input image to copy from
+  @param out output image to copy into
+  @param size size of the area to copy. By default this is the entirty of the
+input image
+  @param begin upper left corner of the area to copy, by default the upper left
+corner of the input image
+  @param dst upper left corner of the destination in the output image, by
+default the upper left corner of the output image
+  @throw ImageRefNotInImage if either begin is not in the input image or dst not
+in the output image
+  @ingroup gImageIO
+  */
+  template<class S, class T> void copy(const BasicImage<S>& in, BasicImage<T>& out, ImageRef size=ImageRef(-1,-1), ImageRef begin = ImageRef(), ImageRef dst = ImageRef())
+  {
+    if (size.x == -1 && size.y == -1)
+      size = in.size();
+    // FIXME: This should be an exception, but which one do I use? 
+    // I refuse to define another "ImageRefNotInImage" in this namespace.
+    if (!(in.in_image(begin) && out.in_image(dst) && in.in_image(begin+size - ImageRef(1,1)) && out.in_image(dst+size - ImageRef(1,1)))){	
+	std::cerr << "bad copy: " << in.size() << " " << out.size() << " " << size << " " << begin << " " << dst << std::endl;
+	int *p = 0;
+	*p = 1;
+    }
+    if (in.size() == out.size() && size == in.size() && begin == ImageRef() && dst == ImageRef()) {
+      Pixel::ConvertPixels<S,T>::convert(in.data(), out.data(), in.totalsize());
+      return;
+    }
+    
+    const S* from = &in[begin];
+    T* to = &out[dst];
+    int i = 0;
+    while (i++<size.y) {
+      Pixel::ConvertPixels<S,T>::convert(from, to, size.x);
+      from += in.size().x;
+      to += out.size().x;
+    }
+  }
+  
+  template <class T, bool pod = Internal::is_POD<T>::is_pod> struct ZeroPixel {
+      static void zero(T& t) { 
+	  for (unsigned int c=0; c<Pixel::Component<T>::count; c++)
+	      Pixel::Component<T>::get(t,c) = 0;
+      }
+  };
+  
+  template <class T> struct ZeroPixel<T,true> {
+      static void zero(T& t) { memset(&t,0,sizeof(T)); }
+  };
+  
+  template <class T, bool pod = Internal::is_POD<T>::is_pod> struct ZeroPixels {
+      static void zero(T* pixels, int count) {
+	  if (count) {
+	      ZeroPixel<T>::zero(*pixels);
+	      std::fill(pixels+1, pixels+count, *pixels);
+	  }
+      }
+  };
+
+  template <class T> struct ZeroPixels<T,true> {
+      static void zero(T* pixels, int count) {
+	  memset(pixels, 0, sizeof(T)*count);
+      }
+  };
+  
+
+  /// Set a pixel to the default value (typically 0)
+  /// For multi-component pixels, this zeros all components (sets them to defaults)
+  template <class T> inline void zeroPixel(T& pixel) { ZeroPixel<T>::zero(pixel); }
+
+  /// Set many pixels to the default value (typically 0)
+  /// For multi-component pixels, this zeros all components (sets them to defaults)
+  template <class T> inline void zeroPixels(T* pixels, int count) {  ZeroPixels<T>::zero(pixels, count);  }
+  
+  /// Set the one-pixel border (top, bottom, sides) of an image to zero values
+  template <class T> void zeroBorders(BasicImage<T>& I)
+  {
+    if (I.size().y == 0)
+      return;
+    zeroPixels(I[0], I.size().x);
+    for (int r=0;r<I.size().y-1; r++)
+	zeroPixels(I[r]+I.size().x-1,2);
+    zeroPixels(I[I.size().y-1], I.size().x);
+  }
+
+  /// Fill image borders
+  /// @param im Image fo fill borders in
+  /// @param pix Fill value
+  /// @param w border width 
+  /// @ingroup gUtility
+  template<class T> void fillBorders(SubImage<T>& im, const T pix, int w=1)
+  {
+	  //Fill the top and bottom
+	  for(int n=0; n < w; n++)
+		  for(int x=0;  x < im.size().x; x++)
+		  {
+			  	im[n][x] = pix;
+				im[im.size().y-1-n][x] = pix;
+		  }
+	
+	  for(int y=w; y < im.size().y - w; y++)
+		  for(int n=0; n < w; n++)
+		  {
+			  im[y][n] = pix;
+			  im[y][im.size().x - 1 - n] = pix;
+		  }	
+
+  }
+
+
+
+
+  /// Compute pointwise differences (a_i - b_i) and store in diff_i
+  /// This is accelerated using SIMD for some platforms and data types (alignment is checked at runtime)
+  /// Do not specify template parameters explicitly so that overloading can choose the right implementation
+  template <class A, class B> inline void differences(const A* a, const A* b, B* diff, size_t count)
+  {
+      while (count--)
+	  *(diff++) = (B)*(a++) - (B)*(b++);
+  }
+
+  /// Compute pointwise (a_i + b_i) * c and add to out_i
+  /// This is accelerated using SIMD for some platforms and data types (alignment is checked at runtime)
+  /// Do not specify template parameters explicitly so that overloading can choose the right implementation
+  template <class A, class B, class C> inline void add_multiple_of_sum(const A* a, const A* b, const C& c,  B* out, size_t count)
+  {
+      while (count--)
+	  *(out++) += (*(a++) + *(b++)) * c;
+  }
+
+  /// Compute pointwise a_i * c and store in out_i
+  /// This is accelerated using SIMD for some platforms and data types (alignment is checked at runtime)
+  /// Do not specify template parameters explicitly so that overloading can choose the right implementation
+      template <class A, class B, class C> inline void assign_multiple(const A* a, const B& c,  C* out, size_t count)
+  {
+      while (count--)
+	  *(out++) = static_cast<C>(*(a++) * c);
+  }
+
+  /// Compute sum(a_i*b_i)
+  /// This is accelerated using SIMD for some platforms and data types (alignment is checked at runtime)
+  /// Do not specify template parameters explicitly so that overloading can choose the right implementation
+  template <class T> double inner_product(const T* a, const T* b, size_t count) {
+      double dot = 0;
+      while (count--)
+	  dot += *(a++) * *(b++);
+      return dot;
+  }
+
+  template <class R, class D, class T> struct SumSquaredDifferences {
+      static inline R sum_squared_differences(const T* a, const T* b, size_t count) {
+	  R ssd = 0;
+	  while (count--) {
+	      D d = *a++ - *b++;
+	      ssd += d*d;
+	  }
+	  return ssd;
+      }
+  };
+
+  template <class T1, class T2> inline void square(const T1* in, T2* out, size_t count) 
+  {
+      while (count--) {
+	  *(out++) = static_cast<T2>(*in * *in);
+	  ++in;
+      }
+  }
+
+  template <class T1, class T2> inline void subtract_square(const T1* in, T2* out, size_t count) 
+  {
+      while (count--) {
+	  *(out++) -= static_cast<T2>(*in * *in);
+	  ++in;
+      }
+  }
+
+  /// Compute sum of (a_i - b_i)^2 (the SSD)
+  /// This is accelerated using SIMD for some platforms and data types (alignment is checked at runtime)
+  /// Do not specify template parameters explicitly so that overloading can choose the right implementation
+  template <class T> inline double sum_squared_differences(const T* a, const T* b, size_t count) {
+      return SumSquaredDifferences<double,double,T>::sum_squared_differences(a,b,count);
+  }
+  
+  /// Check if the pointer is aligned to the specified byte granularity
+  template<int bytes> bool is_aligned(const void* ptr);
+  template<> inline bool is_aligned<8>(const void* ptr) {   return ((reinterpret_cast<size_t>(ptr)) & 0x7) == 0;   }
+  template<> inline bool is_aligned<16>(const void* ptr) {  return ((reinterpret_cast<size_t>(ptr)) & 0xF) == 0;   }
+
+  /// Compute the number of pointer increments necessary to yield alignment of A bytes
+  template<int A, class T> inline size_t steps_to_align(const T* ptr) 
+  {
+      return is_aligned<A>(ptr) ? 0 : (A-((reinterpret_cast<size_t>(ptr)) & (A-1)))/sizeof(T); 
+  }
+
+  void differences(const byte* a, const byte* b, short* diff, unsigned int size);
+  void differences(const short* a, const short* b, short* diff, unsigned int size);
+
+
+  void differences(const float* a, const float* b, float* diff, size_t size);
+  void add_multiple_of_sum(const float* a, const float* b, const float& c,  float* out, size_t count);
+  void assign_multiple(const float* a, const float& c,  float* out, size_t count);
+  double inner_product(const float* a, const float* b, size_t count);
+  double sum_squared_differences(const float* a, const float* b, size_t count);
+  void square(const float* in, float* out, size_t count);
+  void subtract_square(const float* in, float* out, size_t count);
+
+  void differences(const int32_t* a, const int32_t* b, int32_t* diff, size_t size);
+  void differences(const double* a, const double* b, double* diff, size_t size);
+  void add_multiple_of_sum(const double* a, const double* b, const double& c,  double* out, size_t count);
+  void assign_multiple(const double* a, const double& c,  double* out, size_t count);
+  double inner_product(const double* a, const double* b, size_t count);
+  double sum_squared_differences(const double* a, const double* b, size_t count);
+  long long sum_squared_differences(const byte* a, const byte* b, size_t count);
+
+
+}
+
+#endif

--- a/libcvd/utility.h.patched
+++ b/libcvd/utility.h.patched
@@ -5,7 +5,6 @@
 #include <cvd/internal/is_pod.h>
 #include <cvd/internal/pixel_traits.h>
 #include <cvd/internal/convert_pixel_types.h>
-#include <sys/types.h>
 
 namespace CVD { //begin namespace
 

--- a/libcvd/utility.patch
+++ b/libcvd/utility.patch
@@ -1,5 +1,5 @@
 --- build/libcvd-20100511/cvd/utility.h	2009-03-17 20:12:37.000000000 +0100
-+++ utility.h.patch.rmb	2011-08-03 12:25:50.755229012 +0200
++++ utility.h.patched	2011-08-03 12:25:50.755229012 +0200
 @@ -5,6 +5,7 @@
  #include <cvd/internal/is_pod.h>
  #include <cvd/internal/pixel_traits.h>

--- a/libcvd/utility.patch
+++ b/libcvd/utility.patch
@@ -1,0 +1,10 @@
+--- build/libcvd-20100511/cvd/utility.h	2009-03-17 20:12:37.000000000 +0100
++++ utility.h.patch.rmb	2011-08-03 12:25:50.755229012 +0200
+@@ -5,6 +5,7 @@
+ #include <cvd/internal/is_pod.h>
+ #include <cvd/internal/pixel_traits.h>
+ #include <cvd/internal/convert_pixel_types.h>
++#include <sys/types.h>
+ 
+ namespace CVD { //begin namespace
+ 

--- a/libtoon/Makefile
+++ b/libtoon/Makefile
@@ -7,9 +7,10 @@ MD5SUM_FILE = libtoon.tar.gz.md5sum
 
 include $(shell rospack find mk)/download_unpack_build.mk
 
-installed: $(SOURCE_DIR)/unpacked
+installed: wipe $(SOURCE_DIR)/unpacked
 	# build
 	cd $(SOURCE_DIR) && ./configure
+	cd $(SOURCE_DIR)/internal && patch -N < ../../../size_mismatch.patch
 	
 	# copy to common
 	mkdir -p common
@@ -17,7 +18,9 @@ installed: $(SOURCE_DIR)/unpacked
 	mkdir -p common/include/libtoon
 	cp -r $(SOURCE_DIR)/* common/include/libtoon
 	cd common/include && ln -sf libtoon TooN
+	touch ROS_NOBUILD
 clean:
 	rm -rf common $(SOURCE_DIR) $(TARBALL)
+	rm -rf ROS_NOBUILD
 wipe: clean
 	-rm -rf build

--- a/libtoon/size_mismatch.hh.patched
+++ b/libtoon/size_mismatch.hh.patched
@@ -1,0 +1,114 @@
+// -*- c++ -*-
+
+// Copyright (C) 2009 Tom Drummond (twd20@cam.ac.uk),
+// Ed Rosten (er258@cam.ac.uk)
+//
+// This file is part of the TooN Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 2, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING.  If not, write to the Free
+// Software Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+// USA.
+
+// As a special exception, you may use this file as part of a free software
+// library without restriction.  Specifically, if other files instantiate
+// templates or use macros or inline functions from this file, or you compile
+// this file and link it with other files to produce an executable, this
+// file does not by itself cause the resulting executable to be covered by
+// the GNU General Public License.  This exception does not however
+// invalidate any other reasons why the executable file might be covered by
+// the GNU General Public License.
+
+namespace TooN {
+
+// class to generate compile time error
+// general case which doesn't exist
+template<int Size1, int Size2>
+struct SizeMismatch_;
+
+// special cases which do exist
+template<int Size>
+struct SizeMismatch_<Size,Size>{
+  static inline void test(int, int){}
+};
+
+template<int Size>
+struct SizeMismatch_<Dynamic,Size>{
+  static inline void test(int size1, int size2){
+    if(size1!=size2){
+	  #ifdef TOON_TEST_INTERNALS
+	  	throw Internal::SizeMismatch();
+	  #elif !defined TOON_NDEBUG_SIZE
+		  std::cerr << "TooN Size Mismatch" << std::endl;
+		  std::abort();
+	  #endif
+    }
+  }
+};
+
+template<int Size>
+struct SizeMismatch_<Size,Dynamic>{
+  static inline void test(int size1, int size2){
+    if(size1!=size2){
+	  #ifdef TOON_TEST_INTERNALS
+	  	throw Internal::SizeMismatch();
+	  #elif !defined TOON_NDEBUG_SIZE
+		  std::cerr << "TooN Size Mismatch" << std::endl;
+		  std::abort();
+	  #endif
+    }
+  }
+};
+
+template <>
+struct SizeMismatch_<Dynamic,Dynamic>{
+  static inline void test(int size1, int size2){
+    if(size1!=size2){
+	  #ifdef TOON_TEST_INTERNALS
+	  	throw Internal::SizeMismatch();
+	  #elif !defined TOON_NDEBUG_SIZE
+		  std::cerr << "TooN Size Mismatch" << std::endl;
+		  std::abort();
+	  #endif
+    }
+  }
+};
+
+namespace Internal
+{
+	struct BadSize;
+}
+
+template<int Size1, int Size2>
+struct SizeMismatch_
+{
+	static inline void test(int, int)
+	{
+		#ifdef TOON_TEST_INTERNALS
+			throw Internal::StaticSizeMismatch();
+		#else
+			//Internal::BadSize size_mismatch;
+		#endif
+	}
+};
+
+template<int Size1, int Size2>
+struct SizeMismatch
+{
+	static inline void test(int s1, int s2)
+	{
+		SizeMismatch_< (Size1 == Dynamic || Size1 == Resizable)?Dynamic:Size1,
+		               (Size2 == Dynamic || Size2 == Resizable)?Dynamic:Size2 >::test(s1, s2);
+	}
+};
+
+}

--- a/libtoon/size_mismatch.patch
+++ b/libtoon/size_mismatch.patch
@@ -1,0 +1,11 @@
+--- build/libtoon/internal/size_mismatch.hh	2011-06-03 10:26:27.000000000 +0200
++++ size_mismatch.hh.patched	2011-08-03 17:41:04.134884998 +0200
+@@ -96,7 +96,7 @@
+ 		#ifdef TOON_TEST_INTERNALS
+ 			throw Internal::StaticSizeMismatch();
+ 		#else
+-			Internal::BadSize size_mismatch;
++			//Internal::BadSize size_mismatch;
+ 		#endif
+ 	}
+ };


### PR DESCRIPTION
libtoon has a compile error which can easily be fixed: I added the necessary patch file to the build process.

libcvd is needed for monoSLAM: I added an automatic download + compile for libcvd.
