### PR TITLE
adjust MD5 checksum/extraction path according to downloaded version 

### DIFF
--- a/libphidgets/Makefile.tarball
+++ b/libphidgets/Makefile.tarball
@@ -10,7 +10,9 @@ MD5SUM_FILE 	= libphidget.tar.gz.md5sum
 include $(shell rospack find mk)/download_unpack_build.mk
 
 installed: $(SOURCE_DIR)/unpacked
-	cd $(SOURCE_DIR) && ./configure
+	if [ ! -f $(SOURCE_DIR)/Makefile ]; then \
+		cd $(SOURCE_DIR) && ./configure; \
+	fi
 	cd $(SOURCE_DIR) && make
 	mkdir -p include/libphidgets && cp $(SOURCE_DIR)/phidget21.h include/libphidgets/
 	mkdir -p lib && cp $(SOURCE_DIR)/.libs/libphidget21.* lib/

--- a/libphidgets/Makefile.tarball
+++ b/libphidgets/Makefile.tarball
@@ -4,7 +4,7 @@ TARBALL		= build/libphidget.tar.gz
 #TARBALL_URL 	= https://code.ros.org/svn/release/download/thirdparty/libphidget_2.1.7.20100621.tar.gz
 TARBALL_URL 	= http://www.phidgets.com/downloads/libraries/libphidget.tar.gz
 UNPACK_CMD  	= tar zxf
-SOURCE_DIR 	= build/libphidget-2.1.8.20130618
+SOURCE_DIR 	= build/libphidget-2.1.8.20130723
 MD5SUM_FILE 	= libphidget.tar.gz.md5sum
 
 include $(shell rospack find mk)/download_unpack_build.mk

--- a/libphidgets/libphidget.tar.gz.md5sum
+++ b/libphidgets/libphidget.tar.gz.md5sum
@@ -1,1 +1,1 @@
-97c7834e4eb8ae04dd177ab3f4829472  libphidget.tar.gz
+04b4c3a58cf69ecd09431b01471bcd1d  libphidget.tar.gz


### PR DESCRIPTION
... and trigger the configure script only if there exists no Makefile. Otherwise you always have a lot of configure script outputs during the catkin_make process, although nothing changed.
