### PR TITLE
Corrected catkin compile error.

### DIFF
--- a/libphidgets/Makefile.tarball
+++ b/libphidgets/Makefile.tarball
@@ -1,7 +1,7 @@
 all: installed
 
 TARBALL		= build/libphidget.tar.gz
-TARBALL_URL 	= http://www.phidgets.com/downloads/libraries/libphidget-2.1.8.20130618.tar.gz
+TARBALL_URL 	= http://www.phidgets.com/downloads/libraries/libphidget_2.1.8.20130618.tar.gz
 UNPACK_CMD  	= tar zxf
 SOURCE_DIR 	= build/libphidget
 INITIAL_DIR	= build/libphidget-2.1.8.20130618

--- a/libphidgets/Makefile.tarball
+++ b/libphidgets/Makefile.tarball
@@ -1,10 +1,10 @@
 all: installed
 
 TARBALL		= build/libphidget.tar.gz
-#TARBALL_URL 	= https://code.ros.org/svn/release/download/thirdparty/libphidget_2.1.7.20100621.tar.gz
-TARBALL_URL 	= http://www.phidgets.com/downloads/libraries/libphidget.tar.gz
+TARBALL_URL 	= http://www.phidgets.com/downloads/libraries/libphidget-2.1.8.20130618.tar.gz
 UNPACK_CMD  	= tar zxf
-SOURCE_DIR 	= build/libphidget-2.1.8.20130618
+SOURCE_DIR 	= build/libphidget
+INITIAL_DIR	= build/libphidget-2.1.8.20130618
 MD5SUM_FILE 	= libphidget.tar.gz.md5sum
 
 include $(shell rospack find mk)/download_unpack_build.mk

--- a/libphidgets/libphidget.tar.gz.md5sum
+++ b/libphidgets/libphidget.tar.gz.md5sum
@@ -1,1 +1,1 @@
-04b4c3a58cf69ecd09431b01471bcd1d  libphidget.tar.gz
+97c7834e4eb8ae04dd177ab3f4829472  libphidget.tar.gz

--- a/libphidgets/libphidget_2.1.7.20100621.tar.gz.md5sum
+++ b/libphidgets/libphidget_2.1.7.20100621.tar.gz.md5sum
@@ -1,1 +1,0 @@
-7b1c559c49922ad69df52c055b426e42  libphidget_2.1.7.20100621.tar.gz


### PR DESCRIPTION
With only libphidget you get newest version and than first I got version error, but also couldn't compile it after because of 'Java'-something. Now I set up to rename libphidget-\* folder after unpacking. But this is not perfect solution because the version is hard coded, it will be much better if the version can be determined online so libphidget-\* can be autocratically renamed. I tried to solve that but failed...
