### PR TITLE
Fix isolated build failures and missing rospack dep

### DIFF
--- a/libntcan/CMakeLists.txt
+++ b/libntcan/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(libntcan)
 
+find_package(catkin REQUIRED)
 
 if(“${CMAKE_SYSTEM_PROCESSOR}” STREQUAL “x86_64”)
   message(STATUS "++++++++++++++++++++++++++ DETECTED 64 bit +++++++++++++++++++++++++++++++++++")

--- a/libpcan/CMakeLists.txt
+++ b/libpcan/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(libpcan)
 
+find_package(catkin REQUIRED)
+
 add_custom_target(
     build_libpcan ALL
     COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f Makefile.tarball)

--- a/libpcan/package.xml
+++ b/libpcan/package.xml
@@ -16,6 +16,7 @@
   <build_depend>libpopt-dev</build_depend>
   <build_depend>mk</build_depend>
   <build_depend>rosbuild</build_depend>
+  <build_depend>rospack</build_depend>
   <build_depend>linux-headers-generic</build_depend>
 
   <export>

--- a/libphidgets/CMakeLists.txt
+++ b/libphidgets/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(libphidgets)
 
+find_package(catkin REQUIRED)
 
 add_custom_target(
     build_phidget21 ALL

--- a/libphidgets/package.xml
+++ b/libphidgets/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>mk</build_depend>
   <build_depend>rosbuild</build_depend>
+  <build_depend>rospack</build_depend>
   <build_depend>libusb-dev</build_depend>
   <export>
     <cpp lflags="-L${prefix}/lib -lphidget21" cflags="-I${prefix}/include"/>


### PR DESCRIPTION
This PR hopes to solve two issues:

The first is that catkin must be `find_package`'d when using an isolated workspace. To reproduce this bug, simply compile `cob_extern`'s packages using catkin_make_isolated.

The second is that `rospack` is not necessarily present on every system, and since it is used to find `mk`, it needs to be in the `build_depend` list. To reproduce this, simply uninstall `rospack`, use `rosdep` to verify that the build_depends are met, and try to compile `cob_extern`'s packages.

I found another issue that I should mention here, but it is a problem in `rospack`, not here. See https://github.com/ros/rospack/pull/36.

Since this is a complete blocker for building on Fedora, I would appreciate a backport of this to groovy.

Thanks!

--scott
