### PR TITLE
Add missing roslib depends

### DIFF
--- a/libpcan/package.xml
+++ b/libpcan/package.xml
@@ -17,6 +17,7 @@
   <build_depend>mk</build_depend>
   <build_depend>rosbuild</build_depend>
   <build_depend>rospack</build_depend>
+  <build_depend>roslib</build_depend>
   <build_depend>linux-headers-generic</build_depend>
 
   <export>

--- a/libphidgets/package.xml
+++ b/libphidgets/package.xml
@@ -15,6 +15,7 @@
   <build_depend>mk</build_depend>
   <build_depend>rosbuild</build_depend>
   <build_depend>rospack</build_depend>
+  <build_depend>roslib</build_depend>
   <build_depend>libusb-dev</build_depend>
   <export>
     <cpp lflags="-L${prefix}/lib -lphidget21" cflags="-I${prefix}/include"/>


### PR DESCRIPTION
This is needed for rospack to operate correctly.
See https://github.com/ros/rospack/pull/36
