### PR TITLE
Added dpkg to build_depend

### DIFF
--- a/libntcan/package.xml
+++ b/libntcan/package.xml
@@ -11,6 +11,7 @@
   <maintainer email="fmw@ipa.fhg.de">Florian Weisshardt</maintainer>
   <author>Florian Weisshardt</author>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>dpkg</build_depend>
 
   <export>
     <cpp lflags="-Wl,-rpath,${prefix}/common/lib -L${prefix}/common/lib -lntcan" cflags="-I${prefix}/common/include -I${prefix}/common/include/libntcan"/>


### PR DESCRIPTION
If you use dpkg to detect system arch, you must list it as a build dependency so that non-debian systems install it.

dpkg is used as of https://github.com/ipa320/cob_extern/commit/3dfb9d7d7f1cf9b48c9a2edccc0f0fb824d11976
