### PR TITLE
More fixes from Fedora

### DIFF
--- a/libntcan/CMakeLists.txt
+++ b/libntcan/CMakeLists.txt
@@ -49,7 +49,7 @@ add_dependencies(ntcan build_ntcan317)
 
 
 
-install(FILES common/lib/${MYARCH}/libntcan.so common/lib/${MYARCH}/libntcan.so.3 common/lib/${MYARCH}/libntcan.so.3.1.7
+install(PROGRAMS common/lib/${MYARCH}/libntcan.so common/lib/${MYARCH}/libntcan.so.3 common/lib/${MYARCH}/libntcan.so.3.1.7
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   )
 

--- a/libpcan/CMakeLists.txt
+++ b/libpcan/CMakeLists.txt
@@ -40,7 +40,7 @@ add_dependencies(copy_pcan build_libpcan)
 add_dependencies(copy_pcan0 build_libpcan)
 add_dependencies(copy_pcan06 build_libpcan)
 
-install(FILES common/lib/libpcan.so common/lib/libpcan.so.0 common/lib/libpcan.so.0.6
+install(PROGRAMS common/lib/libpcan.so common/lib/libpcan.so.0 common/lib/libpcan.so.0.6
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 

--- a/libphidgets/CMakeLists.txt
+++ b/libphidgets/CMakeLists.txt
@@ -39,7 +39,7 @@ add_dependencies(phidget21 copy_phidget21_plain)
 add_dependencies(phidget21 copy_phidget21)
 add_dependencies(phidget21 copy_phidget210)
 
-install(FILES lib/libphidget21.so lib/libphidget21.so.0 lib/libphidget21.so.0.0.0
+install(PROGRAMS lib/libphidget21.so lib/libphidget21.so.0 lib/libphidget21.so.0.0.0
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 

--- a/libphidgets/package.xml
+++ b/libphidgets/package.xml
@@ -17,6 +17,8 @@
   <build_depend>rospack</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>libusb-dev</build_depend>
+  <run_depend>libusb</run_depend>
+
   <export>
     <cpp lflags="-L${prefix}/lib -lphidget21" cflags="-I${prefix}/include"/>
   </export>


### PR DESCRIPTION
Two more fixes, neither are specific to Fedora, but were found during Fedora compilation.

libusb was added to rosdep for this package, see: https://github.com/ros/rosdistro/commit/5fb538f524af747d5242975bd29363b33fbfeb5f
