### PR TITLE
bugfix after failed releases

### DIFF
--- a/libconcorde_tsp_solver/Makefile.tarball
+++ b/libconcorde_tsp_solver/Makefile.tarball
@@ -6,16 +6,18 @@ TARBALL_URL = https://github.com/ipa320/thirdparty/raw/master/concorde-tsp-solve
 SOURCE_DIR = build/concorde
 UNPACK_CMD = tar xzf
 MD5SUM_FILE = concorde-tsp-solver-20031219.tar.gz.md5sum
+QSOPT_DIR = $(shell pwd)/build/Qsopt
 
 include $(shell rospack find mk)/download_unpack_build.mk
 
 installed: $(SOURCE_DIR)/unpacked
 	# copy to common
+	
 	mkdir -p common/bin
 	#mkdir -p common/include/vl
 	#!!Qsopt is neccessary to solve TSPs with more than 10 nodes!!
 		#you need to have a qsopt.a and a qsopt.h in the source folder and you have to use an absolute path to link it with Concorde
-	cd $(SOURCE_DIR) && ./configure --with-qsopt=$(shell rospack find libconcorde_tsp_solver)/build/Qsopt && make
+	cd $(SOURCE_DIR) && ./configure --with-qsopt=$(QSOPT_DIR)/build/Qsopt && make
 	cp -r $(SOURCE_DIR)/TSP/concorde common/bin
 	#cp $(SOURCE_DIR)/vl/*.h common/include/vl
 	touch installed

--- a/libconcorde_tsp_solver/Makefile.tarball
+++ b/libconcorde_tsp_solver/Makefile.tarball
@@ -12,12 +12,11 @@ include $(shell rospack find mk)/download_unpack_build.mk
 
 installed: $(SOURCE_DIR)/unpacked
 	# copy to common
-	
 	mkdir -p common/bin
 	#mkdir -p common/include/vl
 	#!!Qsopt is neccessary to solve TSPs with more than 10 nodes!!
 		#you need to have a qsopt.a and a qsopt.h in the source folder and you have to use an absolute path to link it with Concorde
-	cd $(SOURCE_DIR) && ./configure --with-qsopt=$(QSOPT_DIR)/build/Qsopt && make
+	cd $(SOURCE_DIR) && ./configure --with-qsopt=$(QSOPT_DIR) && make
 	cp -r $(SOURCE_DIR)/TSP/concorde common/bin
 	#cp $(SOURCE_DIR)/vl/*.h common/include/vl
 	touch installed

--- a/libopengm/Makefile.tarball
+++ b/libopengm/Makefile.tarball
@@ -1,11 +1,11 @@
 all: installed
 
-TARBALL = build/opengm-master.zip
-TARBALL_URL = https://github.com/ipa320/thirdparty/raw/master/opengm-master.zip
+TARBALL = build/opengm-master.tar.gz
+TARBALL_URL = https://github.com/ipa-rmb-fj/thirdparty/raw/master/opengm-master.tar.gz
 #TARBALL_URL = https://github.com/opengm/opengm/archive/master.zip
-SOURCE_DIR = build/opengm
-UNPACK_CMD = unzip -d opengm -q
-MD5SUM_FILE = opengm-master.zip.md5sum
+SOURCE_DIR = build/opengm-master
+UNPACK_CMD = tar xzf
+MD5SUM_FILE = opengm-master.tar.gz.md5sum
 
 include $(shell rospack find mk)/download_unpack_build.mk
 
@@ -14,7 +14,7 @@ installed: $(SOURCE_DIR)/unpacked
 	mkdir -p common
 	mkdir -p common/include	
 
-	cp -r $(SOURCE_DIR)/opengm-master/include/opengm common/include
+	cp -r $(SOURCE_DIR)/include/opengm common/include
 
 	touch installed
 	

--- a/libopengm/Makefile.tarball
+++ b/libopengm/Makefile.tarball
@@ -1,7 +1,7 @@
 all: installed
 
 TARBALL = build/opengm-master.tar.gz
-TARBALL_URL = https://github.com/ipa-rmb-fj/thirdparty/raw/master/opengm-master.tar.gz
+TARBALL_URL = https://github.com/ipa320/thirdparty/raw/master/opengm-master.tar.gz
 #TARBALL_URL = https://github.com/opengm/opengm/archive/master.zip
 SOURCE_DIR = build/opengm-master
 UNPACK_CMD = tar xzf

--- a/libopengm/opengm-master.tar.gz.md5sum
+++ b/libopengm/opengm-master.tar.gz.md5sum
@@ -1,0 +1,1 @@
+414951b2772f4ed5683a6cf6bdd6eb0d  opengm-master.tar.gz

--- a/libopengm/opengm-master.zip.md5sum
+++ b/libopengm/opengm-master.zip.md5sum
@@ -1,1 +1,0 @@
-cb1db1cfafae34132a80f4c1a108a99e  opengm-master.zip


### PR DESCRIPTION
Changed two things:
1. libconcorde_tsp_solver: don't use "rospack find" but "pwd" to find absolute path to Qsopt library
2. libopengm: changed compression format from .zip to .tar.gz
