### PR TITLE
corrected spelling mistake

### DIFF
--- a/cob_extern/package.xml
+++ b/cob_extern/package.xml
@@ -17,7 +17,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>liconcorde_tsp_solver</exec_depend>
+  <exec_depend>libconcorde_tsp_solver</exec_depend>
   <exec_depend>libdlib</exec_depend>
   <exec_depend>libntcan</exec_depend>
   <exec_depend>libpcan</exec_depend>


### PR DESCRIPTION
minor spelling mistake in cob_extern/package.xml prevented the buildfarm to process further, corrected it