### PR TITLE
only build concorde library and header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ env:
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=file
     - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - env: ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/libconcorde_tsp_solver/CMakeLists.txt
+++ b/libconcorde_tsp_solver/CMakeLists.txt
@@ -38,12 +38,11 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     BUILD_IN_SOURCE 1
     BUILD_COMMAND
       COMMAND ${QSOPT_CONFIGURE}  # use special configuration when building with qsopt
-      COMMAND make
+      COMMAND make concorde.a concorde.h
       # copy headers to devel space (catkin does not like headers in source space)
       COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/concorde.h ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}
       # copy libs, set-up soname chain
       COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/concorde.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/TSP/concorde ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}/concorde
     INSTALL_COMMAND ""
 )
 
@@ -58,8 +57,4 @@ install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
 
 install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}/concorde.a
     DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)
-
-install(PROGRAMS ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}/concorde
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
This PR removes building the `concorde` executable in `libconcorde_tsp_solver` to solve https://github.com/ipa320/cob_extern/issues/96.