### PR TITLE
remove dependency on linux-headers-generic

### DIFF
--- a/libpcan/package.xml
+++ b/libpcan/package.xml
@@ -14,6 +14,4 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>linux-headers-generic</depend>
-
 </package>


### PR DESCRIPTION
The rosdep key `linux-headers-generic` will always install the "standard" kernel headers. On Ubuntu LTS, where kernels are updated with point releases, this will depend on the old kernel header files, while a newer kernel image might be booted.

Since the `libpcan` build script depends on the headers of the currently booted kernel anyway, installing the "old" headers does not have an effect.