### PR TITLE
add -Wno-* compile option to suppress warnings

### DIFF
--- a/libdlib/CMakeLists.txt
+++ b/libdlib/CMakeLists.txt
@@ -17,7 +17,7 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     BINARY_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-build
     
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release
+    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release -- -Wno-deprecated-declarations -Wno-terminate
         # copy headers to devel space (catkin does not like headers in source space)
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}
         # copy libs, set-up soname chain

--- a/libphidgets/CMakeLists.txt
+++ b/libphidgets/CMakeLists.txt
@@ -11,7 +11,7 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     URL https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.8.20151217.tar.gz
     URL_MD5 818ab2ff1de92ed9568a206e0e89657f
 
-    CONFIGURE_COMMAND "./configure"
+    CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/configure CFLAGS=-Wno-incompatible-pointer-types\ -Wno-deprecated-declarations
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     BUILD_IN_SOURCE 1
     BUILD_COMMAND make


### PR DESCRIPTION
I **also** would like to suppress the warnings from `libphidgets/ExternalProject` (see https://travis-ci.com/ipa320/cob_extern/jobs/253965974#L439-L517), but I can't figure out a way to do so

@lindemeier @benmaidel @ipa-mdl do you have any idea? any feedback on this pr?