### PR TITLE
[WIP] suppress warnings

### DIFF
--- a/libdlib/CMakeLists.txt
+++ b/libdlib/CMakeLists.txt
@@ -15,8 +15,8 @@ ExternalProject_Add(EP_${PROJECT_NAME}
 
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     BINARY_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-build
-    
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} CFLAGS=-Wno-deprecated-declarations\ -Wno-terminate ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib 
+
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} CFLAGS=-Wno-deprecated-declarations\ -Wno-terminate CXXFLAGS=-Wno-deprecated-declarations\ -Wno-terminate ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release -- -Wno-deprecated-declarations -Wno-terminate
         # copy headers to devel space (catkin does not like headers in source space)
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/libdlib/CMakeLists.txt
+++ b/libdlib/CMakeLists.txt
@@ -16,7 +16,7 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     BINARY_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-build
     
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} CFLAGS=-Wno-deprecated-declarations\ -Wno-terminate ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib 
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release -- -Wno-deprecated-declarations -Wno-terminate
         # copy headers to devel space (catkin does not like headers in source space)
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/dlib ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/libphidgets/CMakeLists.txt
+++ b/libphidgets/CMakeLists.txt
@@ -11,7 +11,7 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     URL https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.8.20151217.tar.gz
     URL_MD5 818ab2ff1de92ed9568a206e0e89657f
 
-    CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/configure CFLAGS=-Wno-incompatible-pointer-types\ -Wno-deprecated-declarations
+    CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/configure CFLAGS=-Wno-incompatible-pointer-types\ -Wno-deprecated-declarations\ -Wno-format-truncation
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     BUILD_IN_SOURCE 1
     BUILD_COMMAND make


### PR DESCRIPTION
follow-up of #102 
for some reasons `libdlib` warnings are still visible in `melodic`
also, in `melodic` `libphidgets` has additional `-Wformat-truncation` warnings