### PR TITLE
[ROS-O] support newer cmake

### DIFF
--- a/libntcan/CMakeLists.txt
+++ b/libntcan/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED)
 
 find_program(CMAKE_DPKG dpkg /bin /usr/bin /usr/local/bin) 
 if(CMAKE_DPKG)
-  exec_program(dpkg ARGS --print-architecture OUTPUT_VARIABLE CMAKE_DPKG_ARCH)
+  execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE CMAKE_DPKG_ARCH)
   if(CMAKE_DPKG_ARCH MATCHES "amd64")
     message(STATUS "++++++++++++++++++++++++++ DETECTED 64 bit +++++++++++++++++++++++++++++++++++")
     set(MYARCH "x86_64")

--- a/libphidgets/CMakeLists.txt
+++ b/libphidgets/CMakeLists.txt
@@ -14,6 +14,7 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/configure CFLAGS=-Wno-incompatible-pointer-types\ -Wno-deprecated-declarations\ -Wno-format-truncation
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     BUILD_IN_SOURCE 1
+    PATCH_COMMAND touch ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/Makefile.in # avoid broken re-generation from old Makefile.am with CMP0135
     BUILD_COMMAND make
         # copy headers to devel space (catkin does not like headers in source space)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/phidget21.h ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/libphidgets/CMakeLists.txt
+++ b/libphidgets/CMakeLists.txt
@@ -8,8 +8,8 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 
 include(ExternalProject)
 ExternalProject_Add(EP_${PROJECT_NAME}
-    URL https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.8.20151217.tar.gz
-    URL_MD5 818ab2ff1de92ed9568a206e0e89657f
+    URL https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.9.20190409.tar.gz
+    URL_MD5 1149757d0b0483520c6b7525d2d62f7d
 
     CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/configure CFLAGS=-Wno-incompatible-pointer-types\ -Wno-deprecated-declarations\ -Wno-format-truncation
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src


### PR DESCRIPTION
[By CMP0153](https://cmake.org/cmake/help/latest/policy/CMP0153.html) The exec_program() command should not be called.

compatible since cmake 3.0, required in cmake 4.2